### PR TITLE
incorrect registry address

### DIFF
--- a/docs/registry/overview.md
+++ b/docs/registry/overview.md
@@ -24,7 +24,7 @@ Each of the child registries are accompanied by a RegistryHandler, which is a co
 | `MetaPoolFactory` |  [0xB9fC157394Af804a3578134A6585C0dc9cc990d4](https://etherscan.io/address/0xB9fC157394Af804a3578134A6585C0dc9cc990d4#code)  |
 | `MetaPoolFactoryHandler` |  [0x127db66E7F0b16470Bec194d0f496F9Fa065d0A9](https://etherscan.io/address/0x127db66E7F0b16470Bec194d0f496F9Fa065d0A9#code)  |
 | `CryptoSwapRegistry` |  [0x9a32aF1A11D9c937aEa61A3790C2983257eA8Bc0](https://etherscan.io/address/0x9a32aF1A11D9c937aEa61A3790C2983257eA8Bc0#code) |
-| `CryptoSwapRegistryHandler` |  [0x22ceb131d3170f9f2FeA6b4b1dE1B45fcfC86E56](https://etherscan.io/address/0x22ceb131d3170f9f2FeA6b4b1dE1B45fcfC86E56#code) |
+| `CryptoSwapRegistryHandler` |  [0x5f493fEE8D67D3AE3bA730827B34126CFcA0ae94](https://etherscan.io/address/0x5f493fEE8D67D3AE3bA730827B34126CFcA0ae94#code) |
 | `CryptoFactory` |  [0xF18056Bbd320E96A48e3Fbf8bC061322531aac99](https://etherscan.io/address/0xF18056Bbd320E96A48e3Fbf8bC061322531aac99#code) |
 | `CryptoFactoryHandler` |  [0xC4F389020002396143B863F6325aA6ae481D19CE](https://etherscan.io/address/0xC4F389020002396143B863F6325aA6ae481D19CE#code)  |
 | `CurveFactory` |  [0x4F8846Ae9380B90d2E71D5e3D042dff3E7ebb40d](https://etherscan.io/address/0x4F8846Ae9380B90d2E71D5e3D042dff3E7ebb40d#code) |


### PR DESCRIPTION
The listed address seems unused and has 0 pool count: https://etherscan.io/address/0x22ceb131d3170f9f2FeA6b4b1dE1B45fcfC86E56#readContract
![image](https://github.com/CurveDocs/curve-docs/assets/86171134/dcde7936-27c9-4b97-a4fa-f40145be93e8)

This appears to be the proper one: https://etherscan.io/address/0x5f493fEE8D67D3AE3bA730827B34126CFcA0ae94#readContract
![image](https://github.com/CurveDocs/curve-docs/assets/86171134/0c4d3ac2-b24b-4e9f-8d89-66fadec90392)

and is the registry in use by the metaregistry https://etherscan.io/address/0xF98B45FA17DE75FB1aD0e7aFD971b0ca00e379fC#readContract
![image](https://github.com/CurveDocs/curve-docs/assets/86171134/41265a46-7e4c-433e-86dc-12bdf85f76d6)

