### PR TITLE
Fix FEE_DENOMINATOR value

### DIFF
--- a/docs/stableswap-ng_exchange/pools/overview.md
+++ b/docs/stableswap-ng_exchange/pools/overview.md
@@ -102,7 +102,7 @@ $xps2 = (xp_{i} + xp_{j})^2$
 
 **The dynamic fee is calculated by the following formula:**
 
-$$\text{dynamic fee} = \frac{{fee_{m} \times fee}}{\frac{(fee_{m} - 10^{18}) \times 4 \times xp_{i} \times xp_{j}}{xps2}+ 10^{18}}$$
+$$\text{dynamic fee} = \frac{{fee_{m} \times fee}}{\frac{(fee_{m} - 10^{10}) \times 4 \times xp_{i} \times xp_{j}}{xps2}+ 10^{10}}$$
 
 
 ??? quote "`Dynamic Fee`"


### PR DESCRIPTION
FEE_DENOMINATOR is defined as a constant 10**10 in the code, not 10**18.

```
FEE_DENOMINATOR: constant(uint256) = 10 ** 10
```

Some text about FEE_DENOMINATOR may be useful to add in this section, but I did not add any in this PR.