### PR TITLE
fix boost factor formula

### DIFF
--- a/docs/curve_dao/liquidity-gauge-and-minting-crv/gauges/LiquidityGaugeV6.md
+++ b/docs/curve_dao/liquidity-gauge-and-minting-crv/gauges/LiquidityGaugeV6.md
@@ -853,7 +853,7 @@ $$\text{lim} = \text{lim} + L \times \frac{\text{voting_balance}}{\text{voting_t
 
 $$\text{lim} = \min(l, \text{lim})$$
 
-$$\text{boost factor} = \frac{lim}{l}$$
+$$\text{boost factor} = \frac{lim}{l \times 0.4}$$
 
 *with:*
 


### PR DESCRIPTION
The boost factor formula was not consistent with the examples and the theoretical maximum of 2.5. Multypling the denominator by 0.4 fixes this.